### PR TITLE
Invert colors of images in dark color schemes

### DIFF
--- a/book/atelier.css
+++ b/book/atelier.css
@@ -6,6 +6,11 @@ main img {
     display: block;
     margin-left: auto;
     margin-right: auto;
+    filter: var(--img-filter);
+}
+
+.navy, .ayu, .coal {
+    --img-filter: invert(90%);
 }
 
 main .caption {


### PR DESCRIPTION
Whene enabling dark themes, the images are not very visible. 
This pull request add some CSS that invert images color when using ayu, coal and navy themes.

The drawback is that some images will be awfull if something else than black schemes are added.

An alternative way could be to add a white background behind images.