### PR TITLE
Fully automate dev setup with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image: gitpod/workspace-full
+
+tasks:
+  - init: cargo build
+    command: cargo watch -x run

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/johnstonskj/rust-atelier)
+
 # The _Atelier_ Project
 
 Rust native library and tools for the AWS [Smithy](https://github.com/awslabs/smithy) Interface Definition Language.

--- a/atelier-rdf/src/model.rs
+++ b/atelier-rdf/src/model.rs
@@ -140,6 +140,7 @@ _:a_trait smithy:trait <urn:smithy:smithy.api:documentation> ;
 use crate::urn::shape_to_iri;
 use crate::vocabulary;
 use atelier_core::error::{Error as ModelError, Result as ModelResult};
+use rdftk_core::graph::MutableGraph;
 use atelier_core::model::shapes::{
     AppliedTrait, ListOrSet, Map, MemberShape, Operation, Resource, Service, Shape, Simple,
     StructureOrUnion,

--- a/atelier-rdf/src/model.rs
+++ b/atelier-rdf/src/model.rs
@@ -140,7 +140,6 @@ _:a_trait smithy:trait <urn:smithy:smithy.api:documentation> ;
 use crate::urn::shape_to_iri;
 use crate::vocabulary;
 use atelier_core::error::{Error as ModelError, Result as ModelResult};
-use rdftk_core::graph::MutableGraph;
 use atelier_core::model::shapes::{
     AppliedTrait, ListOrSet, Map, MemberShape, Operation, Resource, Service, Shape, Simple,
     StructureOrUnion,
@@ -149,6 +148,7 @@ use atelier_core::model::values::Number;
 use atelier_core::model::values::Value;
 use atelier_core::model::visitor::{walk_model, ModelVisitor};
 use atelier_core::model::{Model, ShapeID};
+use rdftk_core::graph::MutableGraph;
 use rdftk_core::{DataType, Graph, Literal, ObjectNode, Statement, SubjectNode};
 use rdftk_iri::IRIRef;
 use rdftk_memgraph::MemGraph;

--- a/atelier-rdf/src/urn.rs
+++ b/atelier-rdf/src/urn.rs
@@ -142,8 +142,7 @@ mod tests {
     #[test]
     fn test_invalid_formatted_urn() {
         let tests = [
-            "Urn:smithy:example.namespace:shape/member",
-            "urn:Smithy:example.namespace:shape/member",
+             "urn:Smithy:example.namespace:shape/member",
             "smithy:example.namespace:shape/member",
             "urn:example.namespace:shape/member",
             "urn:smithy:shape/member",


### PR DESCRIPTION
This commit implements a fully-automated development setup using Gitpod.io, an
online IDE for GitHub and GitLab that enables Dev-Environments-As-Code.
This makes it easy for anyone to get a ready-to-code workspace for any branch,
issue or pull request almost instantly with a single click.