### PR TITLE
fix: remove panic when assembling empty model set

### DIFF
--- a/atelier-assembler/src/lib.rs
+++ b/atelier-assembler/src/lib.rs
@@ -308,13 +308,24 @@ impl TryFrom<&mut ModelAssembler> for Model {
                 .iter()
                 .map(|file_name| value.read_model(&file_name))
                 .collect();
+            debug!(
+                "Model::try_from::<ModelAssembler>(...): found models => {:#?}",
+                &models
+            );
             match models {
                 Ok(mut models) => {
-                    let mut merged = models.remove(0);
-                    for other in models {
-                        merged.merge(other)?;
+                    if models.len() == 0 {
+                        warn!(
+                            "Model::try_from::<ModelAssembler>(...): No models found to assemble!"
+                        );
+                        Ok(Model::default())
+                    } else {
+                        let mut merged = models.remove(0);
+                        for other in models {
+                            merged.merge(other)?;
+                        }
+                        Ok(merged)
                     }
-                    Ok(merged)
                 }
                 Err(err) => Err(err),
             }

--- a/atelier-assembler/tests/assemble_nothing.rs
+++ b/atelier-assembler/tests/assemble_nothing.rs
@@ -1,0 +1,23 @@
+use atelier_assembler::ModelAssembler;
+use atelier_core::model::Model;
+use std::convert::TryFrom;
+use std::path::PathBuf;
+
+const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
+
+#[test]
+fn merge_no_models() {
+    pretty_env_logger::try_init().expect("Could not initialize logger.");
+
+    let mut path = PathBuf::from(MANIFEST_DIR);
+    path.push("tests");
+    path.push("empty");
+
+    let mut assembler = ModelAssembler::default();
+    let _ = assembler.push(&path);
+
+    let model = Model::try_from(assembler);
+    println!("{:#?}", model);
+    assert!(model.is_ok());
+    assert_eq!(model.unwrap(), Model::default());
+}


### PR DESCRIPTION
Before, if you attempted to assemble an empty set of models (i.e. a
directory with no matching smithy/json files), we panicked.

This is handled in TryFrom<ModelAssembler> by explicitly
checking whether the `Vec<Model>` is empty.

Now, in that case you get a warning logged and an default model returned
as Ok().