### PR TITLE
fix: propagate Err up the call stack instead of unwrap()

### DIFF
--- a/atelier-smithy/src/parser/smithy.rs
+++ b/atelier-smithy/src/parser/smithy.rs
@@ -89,7 +89,7 @@ fn parse_idl(input_pair: Pair<'_, Rule>) -> ModelResult<Model> {
             });
             match builder {
                 None => Ok(Model::default()),
-                Some(mut builder) => Ok(builder.meta_data_from(meta_data).try_into().unwrap()),
+                Some(mut builder) => builder.meta_data_from(meta_data).try_into(),
             }
         }
         _ => unexpected!("parse_idl", input_pair),


### PR DESCRIPTION
Removes an unneeded `unwrap()` and allows errors to propagate all the way back up to the original caller.