### PR TITLE
add (disabled) test cases for shape name resolution

### DIFF
--- a/atelier-assembler/tests/assemble_resolver_cases.rs
+++ b/atelier-assembler/tests/assemble_resolver_cases.rs
@@ -5,13 +5,17 @@ use std::path::PathBuf;
 
 const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
+// **************************************************
+// *********** BROKEN TEST BELOW DISABLED ***********
+// **************************************************
+#[cfg(broken_test)]
 #[test]
-fn merge_good_models() {
+fn test_shape_name_resolution() {
     pretty_env_logger::try_init().expect("Could not initialize logger.");
 
     let mut path = PathBuf::from(MANIFEST_DIR);
     path.push("tests");
-    path.push("good");
+    path.push("resolver_cases");
 
     let mut assembler = ModelAssembler::default();
     let _ = assembler.push(&path);

--- a/atelier-assembler/tests/resolver_cases/animal.smithy
+++ b/atelier-assembler/tests/resolver_cases/animal.smithy
@@ -1,0 +1,36 @@
+$version: "1.0"
+
+namespace earth.kingdom.animals
+
+@enum([
+    {
+        value: "Agnatha",
+        name: "Agnatha",
+    },
+    {
+        value: "Chrondrichtyes",
+        name: "Chrondrichtyes",
+    },
+    {
+        value: "Osteichthyes",
+        name: "Osteichthyes",
+    },
+    {
+        value: "Amphibia",
+        name: "Amphibia",
+    },
+    {
+        value: "Reptilia",
+        name: "Reptilia",
+    },
+    {
+        value: "Aves",
+        name: "Aves",
+    },
+    {
+        value: "Mammalia",
+        name: "Mammalia",
+    }
+])
+string Class
+

--- a/atelier-assembler/tests/resolver_cases/dog-breeds.smithy
+++ b/atelier-assembler/tests/resolver_cases/dog-breeds.smithy
@@ -1,0 +1,23 @@
+$version: "1.0"
+
+namespace earth.kingdom.animals.mammals.dogs
+
+@enum([
+    {
+        value: "IrishSetter",
+        name: "Irish Setter",
+    },
+    {
+        value: "GreatDane",
+        name: "Great Dane",
+    },
+    {
+        value: "Vizsla",
+        name: "Vizsla",
+    },
+    {
+        value: "Poodle",
+        name: "Poodle",
+    },
+])
+string Breed

--- a/atelier-assembler/tests/resolver_cases/dog-colors.smithy
+++ b/atelier-assembler/tests/resolver_cases/dog-colors.smithy
@@ -1,0 +1,35 @@
+$version: "1.0"
+
+namespace earth.kingdom.animals.mammals.dogs
+
+@enum([
+    {
+        value: "Red",
+        name: "Red",
+    },
+    {
+        value: "Orange",
+        name: "Orange",
+    },
+    {
+        value: "Yellow",
+        name: "Yellow",
+    },
+    {
+        value: "Green",
+        name: "Green",
+    },
+    {
+        value: "Blue",
+        name: "Blue",
+    },
+    {
+        value: "Indigo",
+        name: "Indigo",
+    },
+    {
+        value: "Violet",
+        name: "Violet",
+    }
+])
+string Color

--- a/atelier-assembler/tests/resolver_cases/dog.smithy
+++ b/atelier-assembler/tests/resolver_cases/dog.smithy
@@ -1,0 +1,19 @@
+$version: "1.0"
+
+namespace earth.kingdom.animals.mammals.dogs
+
+use earth.kingdom.animals#Class
+
+structure Dog {
+    @required
+    @documentation("animal classification (from earth.kingdom.animals#Class)")
+    class: Class,
+
+    @required
+    @documentation("the breed of this dog (from earth.kingdom.animals.mammals.dogs#Breed)")
+    breed: Breed,
+
+    @required
+    @documentation("the color of this dog (from earth.kingdom.animals.mammals.dogs#Color)")
+    color: Color,
+}

--- a/atelier-core/src/builder/mod.rs
+++ b/atelier-core/src/builder/mod.rs
@@ -243,7 +243,7 @@ impl ModelBuilder {
         );
         match shape_name {
             ShapeName::Qualified(qualified) => {
-                debug!("qualified ShapeID exists, use as is");
+                trace!("qualified ShapeID exists, use as is");
                 // If this is a ShapeID already, then just use it as-is.
                 if !qualified.is_member() {
                     Ok(qualified.clone())
@@ -253,7 +253,7 @@ impl ModelBuilder {
                 }
             }
             ShapeName::Local(local) => {
-                debug!("Local ShapeName: proceeding with resolution...");
+                trace!("Local ShapeName: proceeding with resolution...");
                 let references: Vec<&ShapeName> = self
                     .reference_names()
                     .filter(|shape_name| shape_name.shape_name() == local)
@@ -266,13 +266,13 @@ impl ModelBuilder {
                 match references.len() {
                     1 => {
                         // 1. a `use_statement` has imported a shape with the same name
-                        debug!("SUCCESS: a use statement imports this shape explicitly");
+                        trace!("SUCCESS: a use statement imports this shape explicitly");
                         Ok(references.first().unwrap().as_qualified().unwrap().clone())
                     }
                     0 => {
                         if self.shapes.contains_key(shape_name) {
                             // 2. a shape is defined in the same namespace as the shape with the same name
-                            debug!(
+                            trace!(
                                 "SUCCESS: shape found in same namespace as shape with same name"
                             );
                             Ok(self.default_namespace.make_shape(local.clone()))
@@ -281,7 +281,7 @@ impl ModelBuilder {
                             || (is_trait && defined_prelude_traits().contains(&*local.to_string()))
                         {
                             // 3. a shape is defined in the prelude with the same name
-                            debug!("SUCCESS: shape found in prelude with the same name");
+                            trace!("SUCCESS: shape found in prelude with the same name");
                             Ok(prelude_namespace_id().make_shape(local.clone()))
                         } else {
                             // 4. the shape ID is invalid

--- a/atelier-smithy/src/parser/smithy.rs
+++ b/atelier-smithy/src/parser/smithy.rs
@@ -89,7 +89,7 @@ fn parse_idl(input_pair: Pair<'_, Rule>) -> ModelResult<Model> {
             });
             match builder {
                 None => Ok(Model::default()),
-                Some(mut builder) => Ok(builder.meta_data_from(meta_data).try_into().unwrap()),
+                Some(mut builder) => builder.meta_data_from(meta_data).try_into(),
             }
         }
         _ => unexpected!("parse_idl", input_pair),


### PR DESCRIPTION
Note that these test cases are disabled so as not to break CI. Please see line 11 in  atelier-assembler/tests/assemble_resolver_cases.rs: `#[cfg(broken_test)]`.