### PR TITLE
Enable linting and validating models built from multiple input files

### DIFF
--- a/atelier-core/src/io/mod.rs
+++ b/atelier-core/src/io/mod.rs
@@ -65,6 +65,16 @@ pub trait ModelReader {
     fn read(&mut self, r: &mut impl std::io::Read) -> ModelResult<Model>;
 }
 
+///
+/// Trait implemented to build a model from multiple input sources
+///
+pub trait ModelBuilder {
+    ///
+    /// Build model from multiple input sources.
+    ///
+    fn merge<S: AsRef<str>>(&mut self, models: Vec<S>) -> ModelResult<Model>;
+}
+
 // ------------------------------------------------------------------------------------------------
 // Public Functions
 // ------------------------------------------------------------------------------------------------
@@ -89,6 +99,20 @@ where
 pub fn read_model_from_file(r: &mut impl ModelReader, path: PathBuf) -> ModelResult<Model> {
     let mut file = File::open(path)?;
     r.read(&mut file)
+}
+
+///
+/// Build a model from multiple input files
+///
+pub fn build_model_from_files(
+    b: &mut impl ModelBuilder,
+    paths: Vec<PathBuf>,
+) -> ModelResult<Model> {
+    let mut models = Vec::new();
+    for path in paths.iter() {
+        models.push(std::fs::read_to_string(path)?);
+    }
+    b.merge(models)
 }
 
 ///

--- a/atelier-core/src/io/mod.rs
+++ b/atelier-core/src/io/mod.rs
@@ -65,16 +65,6 @@ pub trait ModelReader {
     fn read(&mut self, r: &mut impl std::io::Read) -> ModelResult<Model>;
 }
 
-///
-/// Trait implemented to build a model from multiple input sources
-///
-pub trait ModelBuilder {
-    ///
-    /// Build model from multiple input sources.
-    ///
-    fn merge<S: AsRef<str>>(&mut self, models: Vec<S>) -> ModelResult<Model>;
-}
-
 // ------------------------------------------------------------------------------------------------
 // Public Functions
 // ------------------------------------------------------------------------------------------------
@@ -99,20 +89,6 @@ where
 pub fn read_model_from_file(r: &mut impl ModelReader, path: PathBuf) -> ModelResult<Model> {
     let mut file = File::open(path)?;
     r.read(&mut file)
-}
-
-///
-/// Build a model from multiple input files
-///
-pub fn build_model_from_files(
-    b: &mut impl ModelBuilder,
-    paths: Vec<PathBuf>,
-) -> ModelResult<Model> {
-    let mut models = Vec::new();
-    for path in paths.iter() {
-        models.push(std::fs::read_to_string(path)?);
-    }
-    b.merge(models)
 }
 
 ///

--- a/atelier-smithy/src/reader.rs
+++ b/atelier-smithy/src/reader.rs
@@ -31,3 +31,15 @@ impl ModelReader for SmithyReader {
         parser::parse_model(&content)
     }
 }
+
+impl SmithyReader {
+    /// Merge multiple model files to create a single model
+    pub fn merge<S: AsRef<str>>(&mut self, model_files: Vec<S>) -> Result<Model> {
+        let mut model = Model::default();
+        for partial in model_files.iter() {
+            let m = parser::parse_model(partial.as_ref())?;
+            model.merge(m)?;
+        }
+        Ok(model)
+    }
+}

--- a/cargo-atelier/src/command_line.rs
+++ b/cargo-atelier/src/command_line.rs
@@ -1,6 +1,5 @@
 use crate::{
-    Command, DocumentCommand, File, FileCommand, FileFormat, Files, MultiFileCommand, Options,
-    TransformCommand,
+    Command, DocumentCommand, File, FileFormat, Files, MultiFileCommand, Options, TransformCommand,
 };
 use somedoc::write::OutputFormat;
 use std::error::Error;

--- a/cargo-atelier/src/command_line.rs
+++ b/cargo-atelier/src/command_line.rs
@@ -1,4 +1,7 @@
-use crate::{Command, DocumentCommand, File, FileCommand, FileFormat, Options, TransformCommand};
+use crate::{
+    Command, DocumentCommand, File, FileCommand, FileFormat, Files, MultiFileCommand, Options,
+    TransformCommand,
+};
 use somedoc::write::OutputFormat;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
@@ -29,9 +32,9 @@ pub(crate) struct CommandLine {
 pub(crate) enum SubCommand {
     /// Run standard linter rules on a model file
     Lint {
-        /// The file to read [default: <stdin>]
+        /// The file(s) to read [default: <stdin>]
         #[structopt(long, short)]
-        in_file: Option<PathBuf>,
+        in_files: Vec<PathBuf>,
 
         /// The representation of the input file
         #[structopt(short, long, default_value = "smithy")]
@@ -39,9 +42,9 @@ pub(crate) enum SubCommand {
     },
     /// Run standard validators on a model file
     Validate {
-        /// The file to read [default: <stdin>]
+        /// The file(s) to read [default: <stdin>]
         #[structopt(long, short)]
-        in_file: Option<PathBuf>,
+        in_files: Vec<PathBuf>,
 
         /// The representation of the input file,
         #[structopt(short, long, default_value = "smithy")]
@@ -49,9 +52,9 @@ pub(crate) enum SubCommand {
     },
     /// Convert model from one representation to another
     Convert {
-        /// The file to read [default: <stdin>]
+        /// The file(s) to read [default: <stdin>]
         #[structopt(long, short)]
-        in_file: Option<PathBuf>,
+        in_files: Vec<PathBuf>,
 
         /// The representation of the input file
         #[structopt(short, long, default_value = "smithy")]
@@ -71,9 +74,9 @@ pub(crate) enum SubCommand {
     },
     /// Create human-readable documentation from a model
     Document {
-        /// The file to read [default: <stdin>]
+        /// The file(s) to read [default: <stdin>]
         #[structopt(long, short)]
-        in_file: Option<PathBuf>,
+        in_files: Vec<PathBuf>,
 
         /// The representation of the input file
         #[structopt(short, long, default_value = "smithy")]
@@ -105,39 +108,39 @@ pub fn parse() -> Result<Command, Box<dyn Error>> {
 
     match args.cmd {
         SubCommand::Lint {
-            in_file,
+            in_files,
             read_format,
         } => Ok(Command::Lint(
-            FileCommand {
-                input_file: File {
-                    file_name: in_file,
+            MultiFileCommand {
+                input_files: Files {
+                    file_names: in_files,
                     format: read_format,
                 },
             },
             options,
         )),
         SubCommand::Validate {
-            in_file,
+            in_files,
             read_format,
         } => Ok(Command::Validate(
-            FileCommand {
-                input_file: File {
-                    file_name: in_file,
+            MultiFileCommand {
+                input_files: Files {
+                    file_names: in_files,
                     format: read_format,
                 },
             },
             options,
         )),
         SubCommand::Convert {
-            in_file,
+            in_files,
             read_format,
             out_file,
             write_format,
             namespace,
         } => Ok(Command::Convert(
             TransformCommand {
-                input_file: File {
-                    file_name: in_file,
+                input_files: Files {
+                    file_names: in_files,
                     format: read_format,
                 },
                 output_file: File {
@@ -149,14 +152,14 @@ pub fn parse() -> Result<Command, Box<dyn Error>> {
             options,
         )),
         SubCommand::Document {
-            in_file,
+            in_files,
             read_format,
             out_file,
             write_format,
         } => Ok(Command::Document(
             DocumentCommand {
-                input_file: File {
-                    file_name: in_file,
+                input_files: Files {
+                    file_names: in_files,
                     format: read_format,
                 },
                 output_file: File {

--- a/cargo-atelier/src/lib.rs
+++ b/cargo-atelier/src/lib.rs
@@ -15,8 +15,8 @@ pub struct Options {
 
 #[derive(Debug)]
 pub enum Command {
-    Lint(FileCommand, Options),
-    Validate(FileCommand, Options),
+    Lint(MultiFileCommand, Options),
+    Validate(MultiFileCommand, Options),
     Convert(TransformCommand, Options),
     Document(DocumentCommand, Options),
 }
@@ -35,20 +35,31 @@ pub struct File {
 }
 
 #[derive(Debug)]
+pub struct Files {
+    pub file_names: Vec<PathBuf>,
+    pub format: FileFormat,
+}
+
+#[derive(Debug)]
 pub struct FileCommand {
     pub input_file: File,
 }
 
 #[derive(Debug)]
+pub struct MultiFileCommand {
+    pub input_files: Files,
+}
+
+#[derive(Debug)]
 pub struct TransformCommand {
-    pub input_file: File,
+    pub input_files: Files,
     pub output_file: File,
     pub namespace: Option<String>,
 }
 
 #[derive(Debug)]
 pub struct DocumentCommand {
-    pub input_file: File,
+    pub input_files: Files,
     pub output_file: File,
     pub output_format: OutputFormat,
 }


### PR DESCRIPTION
If a smithy model file contains `use` statements that depend on shapes defined in other model files, `cargo-atelier`'s `lint` and `validate` commands will generate fatal errors because of undefined shapes. If you concatenate all the model files that together define all the relevant shapes, it also fails, because the parser doesn't accept a file with multiple namespace declarations. 

Atelier Models have the ability to merge multiple input sources into a single model, but not from the cli.

This PR makes the merge capability available from the command line by updating `lint`, `validate`, `document`, and `transform` commands to accept multiple input files.

All input files must be the same format (smithy). If multiple input files are attempted for json or another input file format, `cargo-atelier` reports an error and stops.