### PR TITLE
skeleton for openapi implementation

### DIFF
--- a/atelier-openapi/Cargo.toml
+++ b/atelier-openapi/Cargo.toml
@@ -18,3 +18,7 @@ all-features = true
 
 [dependencies]
 atelier_core = { version = "~0.2", path = "../atelier-core" }
+
+[dev-dependencies]
+atelier_test = {version = "0.1", path = "../atelier-test" }
+atelier_smithy = {version = "~0.2", path = "../atelier-smithy" }

--- a/atelier-openapi/src/lib.rs
+++ b/atelier-openapi/src/lib.rs
@@ -1,13 +1,14 @@
-/*!
-Future home of the OpenAPI writer for Smithy.
-
-*/
-
-// use ...
+use atelier_core::io::ModelWriter;
 
 // ------------------------------------------------------------------------------------------------
 // Public Types
 // ------------------------------------------------------------------------------------------------
+
+///
+/// Writes out a model in the [OpenAPI](https://swagger.io/specification/) format.
+///
+#[derive(Debug, Default)]
+pub struct OpenApiWriter {}
 
 // ------------------------------------------------------------------------------------------------
 // Private Types
@@ -20,6 +21,20 @@ Future home of the OpenAPI writer for Smithy.
 // ------------------------------------------------------------------------------------------------
 // Implementations
 // ------------------------------------------------------------------------------------------------
+
+impl ModelWriter for OpenApiWriter {
+    fn write(
+        &mut self,
+        w: &mut impl std::io::Write,
+        _model: &atelier_core::model::Model,
+    ) -> atelier_core::error::Result<()> {
+        writeln!(w, "{{")?;
+        writeln!(w, r#" "openapi": "3.0.2""#)?;
+        writeln!(w, "}}")?;
+
+        Ok(())
+    }
+}
 
 // ------------------------------------------------------------------------------------------------
 // Private Functions

--- a/atelier-openapi/tests/describe_openapi_writer.rs
+++ b/atelier-openapi/tests/describe_openapi_writer.rs
@@ -1,0 +1,53 @@
+use atelier_core::io::{read_model_from_file, write_model_to_string, ModelWriter};
+use atelier_openapi::OpenApiWriter;
+use atelier_smithy::SmithyReader;
+use atelier_test::parse_and_compare_to_files;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+#[test]
+fn test_smithy_prelude() {
+    test("union-test");
+}
+
+const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
+
+// test helper which reads a smithy file, converts it to openapi, and compares with the
+// corresponding openapi spec from the /models directory.
+// just a naive line by line equality check for now until we have a real model to work with
+fn test(file_name: &str) {
+    let source_file = PathBuf::from(format!(
+        "{}/tests/models/{}.smithy",
+        MANIFEST_DIR, file_name
+    ));
+    let expected_file = PathBuf::from(format!(
+        "{}/tests/models/{}.openapi.jsoN",
+        MANIFEST_DIR, file_name
+    ));
+
+    let mut reader = SmithyReader::default();
+    let model = read_model_from_file(&mut reader, PathBuf::from(source_file)).unwrap();
+
+    let mut writer = OpenApiWriter::default();
+    let output = write_model_to_string(&mut writer, &model).unwrap();
+
+    let expected_lines: Vec<String> = fs::read_to_string(expected_file)
+        .unwrap()
+        .split("\n")
+        // .split(LINE_ENDING)
+        .map(|s| {
+            format!(
+                "{:?}",
+                s.replace("\\n", "\n")
+                    .replace("\\t", "\t")
+                    .replace("\\\"", "\"")
+            )
+        })
+        .collect();
+
+    let actual_lines: Vec<&str> = output.split("\n").collect();
+
+    assert_eq!(actual_lines, expected_lines);
+}

--- a/atelier-openapi/tests/models/union-test.openapi.json
+++ b/atelier-openapi/tests/models/union-test.openapi.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Example",
+    "version": "2020-09-11"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "GetItem",
+        "responses": {
+          "200": {
+            "description": "GetItem 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ItemResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Foo": {
+        "type": "object"
+      },
+      "ItemResponse": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "Foo",
+            "properties": {
+              "Foo": {
+                "$ref": "#/components/schemas/Foo"
+              }
+            },
+            "required": ["Foo"]
+          }
+        ]
+      }
+    },
+    "securitySchemes": {
+      "aws.auth.sigv4": {
+        "type": "apiKey",
+        "description": "AWS Signature Version 4 authentication",
+        "name": "Authorization",
+        "in": "header",
+        "x-amazon-apigateway-authtype": "awsSigv4"
+      }
+    }
+  },
+  "security": [
+    {
+      "aws.auth.sigv4": []
+    }
+  ]
+}

--- a/atelier-openapi/tests/models/union-test.smithy
+++ b/atelier-openapi/tests/models/union-test.smithy
@@ -1,0 +1,36 @@
+$version: "1.0"
+
+namespace smithy.example
+
+use aws.api#service
+use aws.auth#sigv4
+use aws.protocols#restJson1
+
+@title("Example")
+@service(sdkId: "Example")
+@sigv4(name: "Example")
+@restJson1
+service Example {
+    version: "2020-09-11",
+    operations: [GetItem],
+}
+
+@http(uri: "/", method: "GET")
+@readonly
+operation GetItem {
+    input: GetItemRequest,
+    output: GetItemResponse,
+}
+
+structure GetItemRequest {}
+
+structure GetItemResponse {
+    @httpPayload
+    item: ItemResponse
+}
+
+union ItemResponse {
+    Foo: Foo,
+}
+
+structure Foo {}


### PR DESCRIPTION
This is the first of what I'm sure will be many, many commits to implement the openapi crate. I'm opening this as a draft PR so I can develop it in the open and get early feedback (which I would very much appreciate!).

My overall plan is to build it TDD style implementing all the tests in https://github.com/awslabs/smithy/tree/main/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy. I've added one of them and some plumbing to run the test. Next step will be to make this test parse.

I looked around briefly and didn't find any openapi crates I liked. They all have additional functionality beyond just struct definitions for the types. I'll probably provide a model implementation in this repo inspired by the others just to reduce a dependency.

I'm excited to contribute!