### PR TITLE
update dependency to address RUSTSEC-2021-0139

### DIFF
--- a/atelier-test/Cargo.toml
+++ b/atelier-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "atelier_test"
 description = "Test and example models used within the other Atelier crates."
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Simon Johnston <johnstonskj@gmail.com>"]
 edition = "2018"
 documentation = "https://docs.rs/atelier_test/"
@@ -12,4 +12,4 @@ publish = true
 
 [dependencies]
 atelier_core = { version = "~0.2", path = "../atelier-core" }
-pretty_assertions = "0.7"
+pretty_assertions = "1.3.0"


### PR DESCRIPTION
cargo-audit identified a RUSTSEC vulnerability in a dependency of atelier_test. This generates a cargo-audit warning in any downstream crate that depends on atelier_test, atelier_assembler, or other crates that indirectly depend on atelier_test.

The affected crate is ansi_term, which is used by pretty_assertions. Updating pretty_assertions to 1.3 eliminates the alert.

```
Crate:     ansi_term
Version:   0.12.1
Warning:   unmaintained
Title:     ansi_term is Unmaintained
Date:      2021-08-18
ID:        RUSTSEC-2021-0139
URL:       https://rustsec.org/advisories/RUSTSEC-2021-0139
Dependency tree:
ansi_term 0.12.1
└── pretty_assertions 0.7.2
    └── atelier_test 0.1.4
```

Other library crates in this repo that depend on atelier_test use the minor version 0.1 so don't need to be updated.

Signed-off-by: stevelr <steve@cosmonic.com>