### PR TITLE
fix has_metadata_value and has_shape result

### DIFF
--- a/atelier-core/src/model/mod.rs
+++ b/atelier-core/src/model/mod.rs
@@ -125,7 +125,7 @@ impl Model {
 
     /// Returns `true` if this model's **metadata** collection has a shape with the provided key`, else `false`.
     pub fn has_metadata_value(&self, key: &str) -> bool {
-        !self.metadata.contains_key(key)
+        self.metadata.contains_key(key)
     }
 
     /// Returns the value in this model's **metadata** collection with the provide key.
@@ -189,7 +189,7 @@ impl Model {
 
     /// Returns `true` if this model's **shapes** collection has a shape with the provided `ShapeID`, else `false`.
     pub fn has_shape(&self, shape_id: &ShapeID) -> bool {
-        !self.shapes.contains_key(shape_id)
+        self.shapes.contains_key(shape_id)
     }
 
     /// Returns the shape in this model's **shapes** collection with the provided `ShapeID`.


### PR DESCRIPTION
# Description

This PR fixes `model.has_metadata_value()` and `model.has_shape()` returns an opposite result.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Environment (please complete the following information):**
 - Platform: [e.g.`uname -a`]
 - Rust [e.g.`rustic -vV`]
 - Cargo [e.g.`cargo -vV`]

# Checklist:

- [x] My code follows the style guidelines of this project (e.g. run `cargo fmt`)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes DO NOT require unstable features without prior agreement
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
